### PR TITLE
Reflect preprocessor integration into houdini core package

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,5 @@
 import adapter from '@sveltejs/adapter-auto';
-import houdini from 'houdini-preprocess';
+import houdini from 'houdini/preprocess';
 import path from 'path';
 import { replaceCodePlugin } from 'vite-plugin-replace';
 import watchAndRun from '@kitql/vite-plugin-watch-and-run';


### PR DESCRIPTION
When following the get started tutorial, the start command will fail due to `houdini-preprocess` not being resolved. I found out the reason is because the package has since been integrated into `houdini`. This PR reflects this.