### PR TITLE
Fix Typescript, CORS errors

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,5 @@
 import { HoudiniClient } from '$houdini'
 
 export default new HoudiniClient({
-	url: 'http://localhost:5173/graphql'
+	url: '/graphql'
 })

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,8 +1,10 @@
 import adapter from '@sveltejs/adapter-auto'
 import path from 'path'
+import preprocess from 'svelte-preprocess'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
+	preprocess: preprocess(),
 	kit: {
 		adapter: adapter(),
 		alias: {


### PR DESCRIPTION
This PR fixes the following errors I encountered during the getting started 

1. TS didn't compile (preprocess plugin was not registered in svelte.config.js)
```
Internal server error: /src/routes/+page.svelte:2:12 Unexpected token
  Plugin: vite-plugin-svelte
  File: /src/routes/+page.svelte:2:12
   1 |  <script lang="ts">import { Container, Display, Sprite, Panel } from "~/components";
   2 |  import type { PageData } from "./$houdini";
                    ^
   3 |  export let data: PageData;
   4 |  
```
3. CORS error (I don't know what caused the error, but it's fixed by pointing the client at a relative url rather than an absolute one)
![image](https://github.com/HoudiniGraphql/intro/assets/5128743/f46ec600-6e20-413c-b118-98d2b930d162)